### PR TITLE
Added recovering to RecursiveWatcher

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ fork in run := true
 
 //mainClass in Compile := Some("tools.Watch")
 mainClass in Compile := Some("bss.Application")
+//mainClass in Compile := Some("tools.Snapshot")
 
 scalariformSettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ version := "0.1"
 
 scalaVersion := "2.11.7"
 
+
 libraryDependencies ++= {
   val akkaVersion = "2.4.1"
 
@@ -13,6 +14,7 @@ libraryDependencies ++= {
     "org.slf4j"                     % "slf4j-api"       % "1.7.14",
     "org.slf4j"                     % "slf4j-simple"    % "1.7.14",
     "com.typesafe.akka"            %% "akka-actor"      % akkaVersion,
+    "org.rocksdb"                   % "rocksdbjni"      % "4.1.0",
 
     "com.typesafe.akka"            %% "akka-testkit"    % akkaVersion    % "test",
     "org.scalatest"                %% "scalatest"       % "2.2.6"        % "test"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -26,5 +26,9 @@ bss {
   root-path = "."
   root-path = ${?BSS_ROOT_PATH}
 
-  monitor-concurrency = 1
+  watcher {
+    db-path = "./dbs/watcher"
+    db-path = ${?BSS_WATCHER_DB_PATH}
+  }
+
 }

--- a/src/main/scala/bss/Application.scala
+++ b/src/main/scala/bss/Application.scala
@@ -28,7 +28,7 @@ object Application extends App {
 
   val router = system.actorOf(EventsRouter.props(rootPath), "EvtRouter")
 
-  system.actorOf(RecursiveWatcher.props(rootPath, router), "RecWatcher")
+  system.actorOf(RecursiveWatcher.props(rootPath, router, dbBasePath = Some(Paths.get("dbs/watcher"))), "RecWatcher")
 
   Await.result(system.whenTerminated, Duration.Inf)
 }

--- a/src/main/scala/bss/Application.scala
+++ b/src/main/scala/bss/Application.scala
@@ -24,11 +24,17 @@ object Application extends App {
 
   implicit val system = ActorSystem("Bss", config)
 
+  sys.addShutdownHook {
+    system.terminate()
+  }
+
   println(s"Watching for ${rootPath.toAbsolutePath}")
 
   val router = system.actorOf(EventsRouter.props(rootPath), "EvtRouter")
 
-  system.actorOf(RecursiveWatcher.props(rootPath, router, dbBasePath = Some(Paths.get("dbs/watcher"))), "RecWatcher")
+  val dbBasePath = Some(Paths.get(bssConfig.getString("watcher.db-path")))
+
+  system.actorOf(RecursiveWatcher.props(rootPath, router, dbBasePath = dbBasePath), "RecWatcher")
 
   Await.result(system.whenTerminated, Duration.Inf)
 }

--- a/src/main/scala/bss/EventsRouter.scala
+++ b/src/main/scala/bss/EventsRouter.scala
@@ -12,7 +12,8 @@ object EventsRouter {
 class EventsRouter(rootPath: Path) extends Actor with ActorLogging {
 
   def receive = {
-    case PathEvent(path, eventType, count) =>
-      log.info(s">>> $eventType ($count) : $path")
+    case PathEvent(eventType, path, isDirectory, count) =>
+      val relPath = rootPath.relativize(path)
+      log.info(s">>> $eventType ($count) : $relPath")
   }
 }

--- a/src/main/scala/bss/RecursiveWatcher.scala
+++ b/src/main/scala/bss/RecursiveWatcher.scala
@@ -1,14 +1,22 @@
 package bss
 
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.nio.file._
 import java.nio.file.StandardWatchEventKinds._
+import java.nio.file.attribute.BasicFileAttributes
+
+import java.security.MessageDigest
 
 import bss.WatcherEvents._
+import org.rocksdb.{ FlushOptions, Options, RocksDB }
 
 import collection.JavaConverters._
 import akka.actor.{ ActorRef, Props, ActorLogging, Actor }
 
 import scala.concurrent.duration.{ DurationDouble, FiniteDuration }
+import scala.util.{ Failure, Success, Try }
 
 object WatcherEvents {
 
@@ -31,47 +39,67 @@ object WatcherEvents {
 
   val AllEventTypes = Seq(Create, Modify, Delete)
 
-  case class PathEvent(path: Path, eventType: EventType, count: Int)
+  case class PathEvent(eventType: EventType, path: Path, isDirectory: Boolean, count: Int = 1)
   case class OverflowEvent()
 }
 
 object RecursiveWatcher {
 
+  private[this] val msgDigest = MessageDigest.getInstance("MD5")
+  def hash(input: Array[Byte]): Array[Byte] = MessageDigest.getInstance("MD5").digest(input)
+
   def props(
     rootPath: Path,
     listener: ActorRef,
     events: Seq[EventType] = AllEventTypes,
-    emptyPollInterval: FiniteDuration = 0.5 seconds
+    emptyPollInterval: FiniteDuration = 0.5 seconds,
+    dbBasePath: Option[Path] = None
   ) =
-    Props(classOf[RecursiveWatcher], rootPath, listener, events, emptyPollInterval)
+    Props(classOf[RecursiveWatcher], rootPath, listener, events, emptyPollInterval,
+      dbBasePath.getOrElse(Paths.get(".").toAbsolutePath().normalize))
 }
 
 class RecursiveWatcher(
   rootPath: Path,
   listener: ActorRef,
   events: Seq[WatcherEvents.EventType],
-  emptyPollInterval: FiniteDuration
+  emptyPollInterval: FiniteDuration,
+  dbBasePath: Path
 )
     extends Actor with ActorLogging {
 
   private[this] case class Poll()
 
-  val kinds = events.map(_.kind)
+  private[this] val kinds = events.map(_.kind)
 
-  var watcher: WatchService = _
-  var subscribers = Map.empty[Path, ActorRef]
+  private[this] var watcher: WatchService = _
+  private[this] var db: RocksDB = _
 
   override def preStart() = {
+    // Initialize the watch service
     watcher = FileSystems.getDefault.newWatchService()
     rootPath.register(watcher, kinds: _*)
-    self ! Poll
+
+    // Initialize the database
+    val options = new Options().setCreateIfMissing(true)
+    Try(RocksDB.open(options, dbBasePath.toString)) match {
+      case Success(value) =>
+        db = value
+        self ! Poll
+
+      case Failure(exception) =>
+        log.error(s"Exception while opening the database at '$dbBasePath': $exception")
+        context.system.terminate()
+    }
   }
 
-  def receive = polling
+  def receive = recovering
 
   def recovering: Receive = {
-    // TODO recovering not implemented yet
     case Poll =>
+      log.info("Recovering state ...")
+      recover()
+      log.info("Polling events ...")
       context.become(polling)
       self ! Poll
   }
@@ -79,6 +107,42 @@ class RecursiveWatcher(
   def polling: Receive = {
     case Poll =>
       poll()
+  }
+
+  def recover() = {
+    def walkPath(path: Path, attrs: BasicFileAttributes, register: Boolean = false): FileVisitResult = {
+      require(path != null)
+      require(attrs != null)
+
+      if (path != rootPath) {
+        if (register)
+          path.register(watcher, kinds: _*)
+
+        dbCheckRecover(db, path, attrs)
+      }
+
+      FileVisitResult.CONTINUE
+    }
+
+    try {
+      Files.walkFileTree(rootPath, new SimpleFileVisitor[Path] {
+        override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+          walkPath(path, attrs, register = true)
+
+        override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+          walkPath(path, attrs)
+
+        //override def postVisitDirectory(path: Path, exc: IOException): FileVisitResult = {
+        //  if (exc != null) throw exc
+        //  FileVisitResult.CONTINUE
+        //}
+      })
+    } catch {
+      case e: IOException =>
+        log.warning(s"Exception while traversing the paths for recovery: $e")
+    }
+
+    db.flush(new FlushOptions().setWaitForFlush(false))
   }
 
   def poll() = {
@@ -99,16 +163,18 @@ class RecursiveWatcher(
 
         val eventType = EventType(kind)
         eventType match {
-          case Create =>
+          case Create | Modify | Delete =>
             val path = absolutePath(key, ctx.asInstanceOf[Path])
-            if (path.toFile.isDirectory) {
+            val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
+
+            if (eventType == Create && attrs.isDirectory) {
               val wk = path.register(watcher, kinds: _*)
               log.debug(s"--> Registered $ctxRepr")
             }
-            notifyPathEvent(path, eventType, count)
-          case Modify | Delete =>
-            val path = absolutePath(key, ctx.asInstanceOf[Path])
-            notifyPathEvent(path, eventType, count)
+
+            dbUpdate(db, path, attrs)
+
+            notifyPathEvent(eventType, path, attrs.isDirectory, count)
 
           case Overflow =>
             log.debug("Watch service overflow")
@@ -126,12 +192,47 @@ class RecursiveWatcher(
     }
   }
 
-  def notifyPathEvent(path: Path, eventType: EventType, count: Int) = {
-    listener ! PathEvent(path, eventType, count)
+  def pathNameHash(path: Path): Array[Byte] = {
+    RecursiveWatcher.hash(path.toString.getBytes(StandardCharsets.UTF_8))
+  }
+
+  def pathAttrsHash(lastModifiedMillis: Long, size: Long): Array[Byte] = {
+    RecursiveWatcher.hash(
+      ByteBuffer.allocate(16)
+        .putLong(lastModifiedMillis)
+        .putLong(size)
+        .array()
+    )
+  }
+
+  def dbCheckRecover(db: RocksDB, path: Path, attrs: BasicFileAttributes): Unit = {
+    val pathKey = pathNameHash(path)
+    val attrsHash = pathAttrsHash(attrs.lastModifiedTime.toMillis, attrs.size)
+
+    Option(db.get(pathKey)) match {
+      case Some(prevAttrsHash) =>
+        if (!prevAttrsHash.sameElements(attrsHash)) {
+          notifyPathEvent(Modify, path, attrs.isDirectory)
+          db.put(pathKey, attrsHash)
+        }
+      case None =>
+        notifyPathEvent(Create, path, attrs.isDirectory)
+        db.put(pathKey, attrsHash)
+    }
+  }
+
+  def dbUpdate(db: RocksDB, path: Path, attrs: BasicFileAttributes) = {
+    val pathKey = pathNameHash(path)
+    val attrsHash = pathAttrsHash(attrs.lastModifiedTime.toMillis, attrs.size)
+    db.put(pathKey, attrsHash)
+  }
+
+  def notifyPathEvent(eventType: EventType, path: Path, isDirectory: Boolean, count: Int = 1) = {
+    listener ! PathEvent(eventType, path, isDirectory, count)
   }
 
   def absolutePath(key: WatchKey, path: Path) = {
     val parentPath = key.watchable().asInstanceOf[Path]
-    parentPath.resolve(path).toAbsolutePath
+    parentPath.resolve(path).toAbsolutePath.normalize()
   }
 }

--- a/src/main/scala/bss/WatcherDb.scala
+++ b/src/main/scala/bss/WatcherDb.scala
@@ -1,0 +1,115 @@
+package bss
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+import java.security.MessageDigest
+
+import bss.WatcherEvents.{ Create, Modify }
+import org.rocksdb.{ FlushOptions, Options, RocksDB }
+
+object WatcherDb {
+  def apply(watcherRootPath: Path, dbBasePath: Path) = new WatcherDb(watcherRootPath, dbBasePath)
+}
+
+class WatcherDb(watcherRootPath: Path, dbBasePath: Path) {
+
+  private[this] val db: RocksDB = {
+    val options = new Options().setCreateIfMissing(true)
+    RocksDB.open(options, dbBasePath.toString)
+  }
+
+  def hash(input: Array[Byte]): Array[Byte] = MessageDigest.getInstance("MD5").digest(input)
+
+  def pathNameHash(path: Path): Array[Byte] = {
+    hash(path.toString.getBytes(StandardCharsets.UTF_8))
+  }
+
+  def pathAttrsHash(lastModifiedMillis: Long, size: Long): Array[Byte] = {
+    hash(ByteBuffer.allocate(16)
+      .putLong(lastModifiedMillis)
+      .putLong(size)
+      .array())
+  }
+
+  def update(path: Path, attrs: BasicFileAttributes) = {
+    val pathKey = pathNameHash(watcherRootPath.relativize(path))
+    val attrsHash = pathAttrsHash(attrs.lastModifiedTime.toMillis, attrs.size)
+    db.put(pathKey, attrsHash)
+  }
+
+  def checkRecover(path: Path, attrs: BasicFileAttributes)(
+    notifyPathEvent: (WatcherEvents.EventType, Path, Boolean) => Unit
+  ): Unit = {
+
+    val pathKey = pathNameHash(watcherRootPath.relativize(path))
+    val attrsHash = pathAttrsHash(attrs.lastModifiedTime.toMillis, attrs.size)
+
+    Option(db.get(pathKey)) match {
+      case Some(prevAttrsHash) =>
+        if (!prevAttrsHash.sameElements(attrsHash)) {
+          notifyPathEvent(Modify, path, attrs.isDirectory)
+          db.put(pathKey, attrsHash)
+        }
+      case None =>
+        notifyPathEvent(Create, path, attrs.isDirectory)
+        db.put(pathKey, attrsHash)
+    }
+  }
+
+  def recover(watcher: WatchService, events: Seq[WatcherEvents.EventType])(
+    notifyPathEvent: (WatcherEvents.EventType, Path, Boolean) => Unit
+  ) = {
+
+    val kinds = events.map(_.kind)
+
+    def walkPath(path: Path, attrs: BasicFileAttributes, register: Boolean = false): FileVisitResult = {
+      require(path != null)
+      require(attrs != null)
+
+      if (path != watcherRootPath) {
+        if (register)
+          path.register(watcher, kinds: _*)
+
+        checkRecover(path, attrs)(notifyPathEvent)
+      }
+
+      FileVisitResult.CONTINUE
+    }
+
+    Files.walkFileTree(watcherRootPath, new SimpleFileVisitor[Path] {
+      override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+        walkPath(path, attrs, register = true)
+
+      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+        walkPath(path, attrs)
+    })
+
+    db.flush(new FlushOptions().setWaitForFlush(false))
+  }
+
+  def snapshot(notifyPathEvent: (WatcherEvents.EventType, Path, Boolean) => Unit = { (_, _, _) => }) = {
+
+    def walkPath(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      require(path != null)
+      require(attrs != null)
+
+      if (path != watcherRootPath)
+        checkRecover(path, attrs)(notifyPathEvent)
+
+      FileVisitResult.CONTINUE
+    }
+
+    Files.walkFileTree(watcherRootPath, new SimpleFileVisitor[Path] {
+      override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult = walkPath(path, attrs)
+      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = walkPath(path, attrs)
+    })
+
+    db.flush(new FlushOptions().setWaitForFlush(false))
+  }
+
+  def close() = {
+    db.close()
+  }
+}

--- a/src/main/scala/tools/Snapshot.scala
+++ b/src/main/scala/tools/Snapshot.scala
@@ -1,0 +1,24 @@
+package tools
+
+import java.nio.file._
+
+import bss.WatcherDb
+import com.typesafe.config.ConfigFactory
+
+object Snapshot extends App {
+
+  if (args.size != 1) {
+    println("Usage: Snapshot <path>")
+    sys.exit(-1)
+  }
+
+  val rootPath = Paths.get(args(0)).toAbsolutePath
+
+  val config = ConfigFactory.load()
+
+  val dbBasePath = Paths.get(config.getString("bss.watcher.db-path"))
+
+  WatcherDb(rootPath, dbBasePath).snapshot { (eventType, path, isDirectory) =>
+    println(s"--> $eventType $path")
+  }
+}


### PR DESCRIPTION
Now the watcher is able to see what changes occurred while it was offline and recover the events the next time it is started.

It uses a RocksDB database to keep hashes of the paths and its attributes (lastModificationTime and size). By default the database is stored at dbs/watcher. The configuration requires a bit more elaboration, so please don't merge this PR until I finish the configuration stuff.