### PR TITLE
Fixed: lost events when subtrees created very fast

### DIFF
--- a/src/main/scala/bss/EventsRouter.scala
+++ b/src/main/scala/bss/EventsRouter.scala
@@ -3,7 +3,7 @@ package bss
 import java.nio.file.Path
 
 import akka.actor.{ Props, ActorLogging, Actor }
-import bss.WatcherEvents.PathEvent
+import bss.RecursiveWatcher.PathEvent
 
 object EventsRouter {
   def props(rootPath: Path) = Props(classOf[EventsRouter], rootPath)
@@ -14,6 +14,6 @@ class EventsRouter(rootPath: Path) extends Actor with ActorLogging {
   def receive = {
     case PathEvent(eventType, path, isDirectory, count) =>
       val relPath = rootPath.relativize(path)
-      log.info(s">>> $eventType ($count) : $relPath")
+      log.info(s">>> $eventType : $relPath")
   }
 }

--- a/src/main/scala/bss/RecursiveWatcher.scala
+++ b/src/main/scala/bss/RecursiveWatcher.scala
@@ -1,43 +1,19 @@
 package bss
 
-import java.nio.file.StandardWatchEventKinds._
 import java.nio.file._
-import java.nio.file.attribute.BasicFileAttributes
 import java.security.MessageDigest
 
 import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
-import bss.WatcherEvents._
+import bss.RecursiveWatcher.PathEvent
+import bss.Watcher._
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.{ DurationDouble, FiniteDuration }
 import scala.util.{ Failure, Success, Try }
 
-object WatcherEvents {
-
-  sealed trait EventType { def kind: WatchEvent.Kind[_] }
-  case object Create extends EventType { val kind = ENTRY_CREATE }
-  case object Modify extends EventType { val kind = ENTRY_MODIFY }
-  case object Delete extends EventType { val kind = ENTRY_DELETE }
-  case object Overflow extends EventType { val kind = OVERFLOW }
-  case class Unknown(val kind: WatchEvent.Kind[_]) extends EventType
-
-  object EventType {
-    def apply(kind: WatchEvent.Kind[_]): EventType = kind.name match {
-      case "ENTRY_CREATE" => Create
-      case "ENTRY_MODIFY" => Modify
-      case "ENTRY_DELETE" => Delete
-      case "OVERFLOW" => Overflow
-      case _ => Unknown(kind) //new EventType { val kind = kind }
-    }
-  }
-
-  val AllEventTypes = Seq(Create, Modify, Delete)
+object RecursiveWatcher {
 
   case class PathEvent(eventType: EventType, path: Path, isDirectory: Boolean, count: Int = 1)
   case class OverflowEvent()
-}
-
-object RecursiveWatcher {
 
   private[this] val msgDigest = MessageDigest.getInstance("MD5")
   def hash(input: Array[Byte]): Array[Byte] = MessageDigest.getInstance("MD5").digest(input)
@@ -56,7 +32,7 @@ object RecursiveWatcher {
 class RecursiveWatcher(
   rootPath: Path,
   listener: ActorRef,
-  events: Seq[WatcherEvents.EventType],
+  events: Seq[EventType],
   emptyPollInterval: FiniteDuration,
   dbBasePath: Path
 )
@@ -66,16 +42,17 @@ class RecursiveWatcher(
 
   private[this] val kinds = events.map(_.kind)
 
-  private[this] var watcher: WatchService = _
+  //private[this] var watcher: WatchService = _
+  private[this] var watcher: Watcher = _
   private[this] var db: WatcherDb = _
 
   override def preStart() = {
     // Initialize the watch service
     log.info("Creating the watch service ...")
-    Try(FileSystems.getDefault.newWatchService()) match {
+    Try(Watcher(rootPath)) match {
       case Success(value) =>
         watcher = value
-        Try(rootPath.register(watcher, kinds: _*)) match {
+        Try(watcher.register(rootPath)) match {
           case Failure(exception) =>
             log.error(s"Exception while registering for '$rootPath': $exception")
             context.system.terminate()
@@ -133,64 +110,28 @@ class RecursiveWatcher(
   }
 
   def recover() = {
-    db.recover(watcher, events) { (eventType, path, isDirectory) =>
+    watcher.recover(db) { (eventType, path, isDirectory) =>
       notifyPathEvent(eventType, path, isDirectory)
     }
   }
 
   def poll() = {
-    val key = watcher.poll()
-    if (key != null) {
-      for (event <- key.pollEvents().asScala) {
-        val kind = event.kind()
-        val kindName = kind.name()
-        val count = event.count()
-        val ctx = event.context()
-        val ctxClassName = ctx.getClass.getCanonicalName
-        val ctxRepr = ctx match {
-          case path: Path => rootPath.relativize(absolutePath(key, path)).toString
-          case _ => ctx.toString
-        }
+    def notifyOverflow() = {
+      log.debug("Watch service overflow")
+      context.become(recovering)
+    }
 
-        log.debug(s"==> $kindName ($count) : $ctxClassName [$ctxRepr]")
+    watcher.poll(db)(notifyPathEvent, notifyOverflow, { s => log.debug(s) }) match {
+      case true =>
+        self ! Poll
 
-        val eventType = EventType(kind)
-        eventType match {
-          case Create | Modify | Delete =>
-            val path = absolutePath(key, ctx.asInstanceOf[Path])
-            val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
-
-            if (eventType == Create && attrs.isDirectory) {
-              val wk = path.register(watcher, kinds: _*)
-              log.debug(s"--> Registered $ctxRepr")
-            }
-
-            db.update(path, attrs)
-
-            notifyPathEvent(eventType, path, attrs.isDirectory, count)
-
-          case Overflow =>
-            log.debug("Watch service overflow")
-            context.become(recovering)
-
-          case _ =>
-            log.debug(s"Unknown event type: $kindName")
-        }
-      }
-      key.reset()
-      self ! Poll
-    } else {
-      import scala.concurrent.ExecutionContext.Implicits.global
-      context.system.scheduler.scheduleOnce(emptyPollInterval, self, Poll)
+      case false =>
+        import scala.concurrent.ExecutionContext.Implicits.global
+        context.system.scheduler.scheduleOnce(emptyPollInterval, self, Poll)
     }
   }
 
-  def notifyPathEvent(eventType: EventType, path: Path, isDirectory: Boolean, count: Int = 1) = {
-    listener ! PathEvent(eventType, path, isDirectory, count)
-  }
-
-  def absolutePath(key: WatchKey, path: Path) = {
-    val parentPath = key.watchable().asInstanceOf[Path]
-    parentPath.resolve(path).toAbsolutePath.normalize()
+  def notifyPathEvent(eventType: EventType, path: Path, isDirectory: Boolean /*, count: Int = 1*/ ) = {
+    listener ! PathEvent(eventType, path, isDirectory)
   }
 }

--- a/src/main/scala/bss/Watcher.scala
+++ b/src/main/scala/bss/Watcher.scala
@@ -1,0 +1,149 @@
+package bss
+
+import java.nio.file.StandardWatchEventKinds._
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+
+import org.rocksdb.FlushOptions
+
+import bss.Watcher._
+
+object Watcher {
+
+  sealed trait EventType { def kind: WatchEvent.Kind[_] }
+  case object Create extends EventType { val kind = ENTRY_CREATE }
+  case object Modify extends EventType { val kind = ENTRY_MODIFY }
+  case object Delete extends EventType { val kind = ENTRY_DELETE }
+  case object Overflow extends EventType { val kind = OVERFLOW }
+  case class Unknown(val kind: WatchEvent.Kind[_]) extends EventType
+
+  object EventType {
+    def apply(kind: WatchEvent.Kind[_]): EventType = kind.name match {
+      case "ENTRY_CREATE" => Create
+      case "ENTRY_MODIFY" => Modify
+      case "ENTRY_DELETE" => Delete
+      case "OVERFLOW" => Overflow
+      case _ => Unknown(kind) //new EventType { val kind = kind }
+    }
+  }
+
+  val AllEventTypes = Seq(Create, Modify, Delete)
+
+  type NotifyPathCallback = (EventType, Path, Boolean) => Unit
+
+  def apply(rootPath: Path, events: Seq[EventType] = AllEventTypes) = new Watcher(rootPath, events)
+}
+
+class Watcher(val rootPath: Path, events: Seq[EventType]) {
+
+  val kinds = events.map(_.kind)
+
+  val watchService = FileSystems.getDefault.newWatchService()
+
+  rootPath.register(watchService, kinds: _*)
+
+  def close() = watchService.close()
+
+  def register(path: Path) = path.register(watchService, kinds: _*)
+
+  def recover(db: WatcherDb, fromPath: Path = rootPath)(notifyPathEvent: NotifyPathCallback) = {
+
+    def walkPath(path: Path, attrs: BasicFileAttributes, register: Boolean = false): FileVisitResult = {
+      require(path != null)
+      require(attrs != null)
+
+      if (path != fromPath) {
+        if (register)
+          path.register(watchService, kinds: _*)
+
+        db.checkRecover(path, attrs)(notifyPathEvent)
+      }
+
+      FileVisitResult.CONTINUE
+    }
+
+    Files.walkFileTree(fromPath, new SimpleFileVisitor[Path] {
+      override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+        walkPath(path, attrs, register = true)
+
+      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult =
+        walkPath(path, attrs)
+    })
+
+    db.flush(false)
+  }
+
+  def snapshot(db: WatcherDb)(notifyPathEvent: NotifyPathCallback = { (_, _, _) => }) = {
+
+    def walkPath(path: Path, attrs: BasicFileAttributes): FileVisitResult = {
+      require(path != null)
+      require(attrs != null)
+
+      if (path != rootPath)
+        db.checkRecover(path, attrs)(notifyPathEvent)
+
+      FileVisitResult.CONTINUE
+    }
+
+    Files.walkFileTree(rootPath, new SimpleFileVisitor[Path] {
+      override def preVisitDirectory(path: Path, attrs: BasicFileAttributes): FileVisitResult = walkPath(path, attrs)
+      override def visitFile(path: Path, attrs: BasicFileAttributes): FileVisitResult = walkPath(path, attrs)
+    })
+
+    db.flush(false)
+  }
+
+  def poll(db: WatcherDb)(notifyPathEvent: NotifyPathCallback, notifyOverflow: () => Unit,
+    debug: => (String => Unit)): Boolean = {
+    import collection.JavaConverters._
+
+    def absolutePath(key: WatchKey, path: Path) = {
+      val parentPath = key.watchable().asInstanceOf[Path]
+      parentPath.resolve(path).toAbsolutePath.normalize()
+    }
+
+    val key = watchService.poll()
+    if (key != null) {
+      for (event <- key.pollEvents().asScala) {
+        val kind = event.kind()
+        val kindName = kind.name()
+        val count = event.count()
+        val ctx = event.context()
+        val ctxClassName = ctx.getClass.getCanonicalName
+        val ctxRepr = ctx match {
+          case path: Path => rootPath.relativize(absolutePath(key, path)).toString
+          case _ => ctx.toString
+        }
+
+        debug(s"==> $kindName ($count) : $ctxClassName [$ctxRepr]")
+
+        val eventType = EventType(kind)
+        eventType match {
+          case Create | Modify | Delete =>
+            val path = absolutePath(key, ctx.asInstanceOf[Path])
+            val attrs = Files.readAttributes(path, classOf[BasicFileAttributes])
+
+            if (eventType == Create && attrs.isDirectory) {
+              val wk = register(path)
+              debug(s"--> Registered $ctxRepr")
+              recover(db, path)(notifyPathEvent)
+            }
+
+            db.update(path, attrs)
+
+            notifyPathEvent(eventType, path, attrs.isDirectory) //, count)
+
+          case Overflow =>
+            notifyOverflow()
+
+          case _ =>
+            debug(s"Unknown event type: $kindName")
+        }
+      }
+      key.reset()
+
+      true
+    } else
+      false
+  }
+}

--- a/src/main/scala/tools/Snapshot.scala
+++ b/src/main/scala/tools/Snapshot.scala
@@ -2,7 +2,7 @@ package tools
 
 import java.nio.file._
 
-import bss.WatcherDb
+import bss.{ Watcher, WatcherDb }
 import com.typesafe.config.ConfigFactory
 
 object Snapshot extends App {
@@ -18,7 +18,8 @@ object Snapshot extends App {
 
   val dbBasePath = Paths.get(config.getString("bss.watcher.db-path"))
 
-  WatcherDb(rootPath, dbBasePath).snapshot { (eventType, path, isDirectory) =>
+  val db = WatcherDb(rootPath, dbBasePath)
+  Watcher(rootPath).snapshot(db) { (eventType, path, isDirectory) =>
     println(s"--> $eventType $path")
   }
 }


### PR DESCRIPTION
When several levels of subfolders are created rapidly, the watcher gets lost and doesn't follows the subtree events up to the leaves loosing all the notifications for them.
The solution is to do a tree traversal (using the same code I had for the initial recovery) after registering new folders.
I extracted all the watching logic into its own class `Watcher`.